### PR TITLE
Java and Git updates

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,5 +7,7 @@ long_description 'Installs/Configures chef-cd-workshop'
 version          '0.1.0'
 
 depends 'yum'
+depends 'java'
 depends 'jenkins'
 depends 'chef-dk'
+depends 'git'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -14,9 +14,8 @@ yum_repository 'epel' do
   action :create
 end
 
-package 'git' do
-  action :install
-end
+
+include_recipe 'git::source'
 
 chef_dk 'ChefDK' do 
   action :install
@@ -39,7 +38,12 @@ service 'docker' do
 end
 
 # Install jenkins
-include_recipe 'jenkins::java'
+node.default['java']['jdk_version'] = '7'
+node.default['java']['install_flavor'] = 'oracle'
+node.default['java']['oracle']['accept_oracle_download_terms'] = true
+
+#include_recipe 'jenkins::java'
+include_recipe 'java'
 include_recipe 'jenkins::master'
 
 # Add Jenkins to the Docker group so it create new containers


### PR DESCRIPTION
Install git from source.  The git package in the repos is too old for ghprb plugin.
Install oracle java.  Jenkins seems to have problems with some versions of OpenJDK.
